### PR TITLE
Fix storage test 'TestPebbleWritesSameSSTs' on big endian

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -63,6 +63,9 @@ using internal::kMaximumTagLength;
 // input. Of course, it doesn't hurt if the hash function is reasonably fast
 // either, as it gets called a lot.
 static inline uint32 HashBytes(uint32 bytes, int shift) {
+#if defined(SNAPPY_IS_BIG_ENDIAN)
+  bytes = bswap_32(bytes);
+#endif
   uint32 kMul = 0x1e35a7bd;
   return (bytes * kMul) >> shift;
 }


### PR DESCRIPTION
The test 'TestPebbleWritesSameSSTs' within the storage package was failing
on s390x architecture. It was determined that snappy compression code was
causing the test failure. The hash function in the snappy compression algorithm
was causing a hash table collision during compression on big-endian systems.
Compression produced different output than the equivalent code in GO causing the
test case failure. The solution implemented was to byte swap the input into the hash
function on big-endian systems as to match the little-endian input.

This test is more of a sanity check, however, it's important since it ensures that the
equivalent GO code is still producing the correct output (even on big-endian systems).
This fix should not affect the test on little-endian systems, this was confirmed
through testing on intel x64.